### PR TITLE
At least InfluxDB 0.9.5 requires different syntax to show retention policies

### DIFF
--- a/lib/one2influx/influx.rb
+++ b/lib/one2influx/influx.rb
@@ -56,7 +56,7 @@ class One2Influx::Influx
   # @return [boolean]
   def db_exists?
     uri = URI('/query')
-    query = {:q => "SHOW RETENTION POLICIES #{@db}"}
+    query = {:q => "SHOW RETENTION POLICIES ON #{@db}"}
     uri.query = URI.encode_www_form(query)
 
     req = Net::HTTP::Get.new(uri.to_s)


### PR DESCRIPTION
This change will make one2influx pass the InfluxDB configuration check.
